### PR TITLE
Replies

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,14 @@
-let myPromise = messenger.messageDisplayScripts.register({
-    js: [
-        { file: "/change_message.js"}
-    ],
-});
+let myPromises = [
+    messenger.messageDisplayScripts.register({
+      js: [
+          { file: "/change_message.js"}
+      ],
+    }),
+    messenger.composeScripts.register({
+      js: [
+          { file: "/change_message.js"},
+          { file: "/change_replies.js"}
+      ],
+    }),
+];
+

--- a/change_message.js
+++ b/change_message.js
@@ -1,5 +1,5 @@
 let outlook_regex = new RegExp('/https://\w+\.safelinks\.protection\.outlook\.com/\?url=(\S+)\&amp;data[^\s"\']*', "g");
-let proofpoint_regex = new RegExp('https://urldefense(?:\.proofpoint)?\.com/(v[0-9])/');
+let proofpoint_regex = new RegExp('https://urldefense(?:\.proofpoint)?\.com/(v[0-9])/[^ ]+');
 
 function safelinkDecoder (str) {
     return str.replace(outlook_regex, (safelinkUri, encodedUri) => decodeURIComponent(encodedUri));

--- a/change_replies.js
+++ b/change_replies.js
@@ -1,0 +1,19 @@
+// Clean all plain-text links in new messages (replies etc.)
+// Logic copied from https://github.com/phavekes/unmangleOutlookSafelinks
+var doc = document.body;
+let proofpoint_regex_g = RegExp(proofpoint_regex, "g")
+var spans = doc.getElementsByTagName("span");
+for (var i=0; i < spans.length; i++) {
+	var span = spans[i];
+	for (var j=0; j < span.childNodes.length; j++) {
+		var node = span.childNodes[j]
+		if (node.nodeName == '#text') {
+			node.textContent = node.textContent.replaceAll(outlook_regex, safelinkDecoder).replaceAll(proofpoint_regex_g, proofPointDecoder)
+		}
+	}
+}
+var pres = doc.getElementsByTagName("pre");
+for (var i=0; i < pres.length; i++) {
+	pres[i].textContent = pres[i].textContent.replaceAll(outlook_regex, safelinkDecoder).replaceAll(proofpoint_regex_g, proofPointDecoder)
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
   },
   "permissions": [
     "messagesRead",
-    "messagesModify"
+    "messagesModify",
+    "compose"
   ],
   "background": {
     "scripts": [


### PR DESCRIPTION
Adds a composeScript that also unmangles URLs in replies to emails, preventing them from ruining replies on mailing lists etc. (and nesting multiple times when ping-ponging through replies between systems with different manglers). Sadly doesn't seem able to modify forwarded emails.

This is not rebased on the current main branch because I was having trouble getting the current main branch to actually work. It's a pretty trivial patch, however, so should hopefully be easy to rebase.